### PR TITLE
enable ld_preload for android target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate libc;
 
-#[cfg(target_env = "gnu")]
+#[cfg(any(target_env = "gnu", target_os = "android"))]
 pub mod ld_preload;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]


### PR DESCRIPTION
Hi, I was trying to build a shared library with the `aarch64-linux-android` target (for use with Termux) and it didn't work because `ld_preload` module is enabled for `gnu` targets only.

After the following change, I was indeed able to run the resulting binary on Android and it worked as expected, so I propose this PR.